### PR TITLE
Allow .peggy extension

### DIFF
--- a/src/prettier-plugin-pegjs.js
+++ b/src/prettier-plugin-pegjs.js
@@ -117,7 +117,7 @@ function handleRemainingComment(comment, text, options, ast, isLastComment) {
 export const languages = [
     {
         name: "pegjs",
-        extensions: [".pegjs"],
+        extensions: [".pegjs", ".peggy"],
         parsers: ["pegjs-parser"],
     },
 ];


### PR DESCRIPTION
Allows the extension of peggy, which is a successor to pegjs.

https://github.com/peggyjs/peggy
